### PR TITLE
Update solution for Visual Studio 18 compatibility

### DIFF
--- a/XpenseTrax.sln
+++ b/XpenseTrax.sln
@@ -1,7 +1,6 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.12.35527.113
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11505.172 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XpenseTrax.API", "backend\XpenseTrax.API\XpenseTrax.API.csproj", "{12345678-ABCD-4321-EFAB-567890ABCDEF}"
 EndProject


### PR DESCRIPTION
Changed VisualStudioVersion in XpenseTrax.sln from 17 to 18 to ensure compatibility with Visual Studio 18. No project structure or configuration changes were made.